### PR TITLE
Install ts-node globally in CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,5 +35,5 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - run: npm install ts-node
+      - run: npm install -g ts-node
       - run: ./deployment/deploy.sh


### PR DESCRIPTION
In order for our deploy script to use this, it needs to be in the path.