### PR TITLE
Add default AWS region to deployment AWS CLI commands

### DIFF
--- a/deployment/deploy.ts
+++ b/deployment/deploy.ts
@@ -283,4 +283,4 @@ async function main() {
   }
 }
 
-main().catch(console.error);
+main();

--- a/deployment/deploy.ts
+++ b/deployment/deploy.ts
@@ -110,6 +110,10 @@ async function awsSpawn(args: string[], options: SpawnOptions = {}) {
       ...options.env,
       AWS_ACCESS_KEY_ID: config.aws.accessKeyId,
       AWS_SECRET_ACCESS_KEY: config.aws.secretAccessKey,
+      // When the AWS CLI is run in GitHub Actions, it makes an IMDS request which requires a region.
+      // Callers are always expected to override this default region with an arg if the call is region-specific.
+      // https://github.com/aws/aws-cli/issues/5234
+      AWS_DEFAULT_REGION: "us-east-1",
       PATH: process.env.PATH,
     },
   });


### PR DESCRIPTION
I was hitting an error in earlier testing but chalked it up to missing secrets. It turns out there's a particularity with how the AWS CLI is run in the GitHub Actions execution context which requires a default region.

This PR adds that default (with comment for context) and removes some unnecessary error handling which was masking the issue.