### PR TITLE
Move internal npm packages to dopplerhq scope

### DIFF
--- a/agent-core/package.json
+++ b/agent-core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-core",
+  "name": "@dopplerhq/agent-core",
   "version": "1.0.0",
   "type": "module",
   "description": "",

--- a/apps/aws-mysql-rotator/app.ts
+++ b/apps/aws-mysql-rotator/app.ts
@@ -1,6 +1,6 @@
-import { JWKSOption, processRequest } from "agent-core";
-import mysqlHandler from "mysql-rotator";
-import { fetchS3KeySet } from "aws-utils";
+import { JWKSOption, processRequest } from "@dopplerhq/agent-core";
+import mysqlHandler from "@dopplerhq/mysql-rotator";
+import { fetchS3KeySet } from "@dopplerhq/aws-utils";
 
 export async function handler(event: { body: string }) {
   let keySetOption: JWKSOption;

--- a/apps/aws-mysql-rotator/package.json
+++ b/apps/aws-mysql-rotator/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "aws-mysql-rotator",
+  "name": "@dopplerhq/aws-mysql-rotator",
   "version": "1.0.0",
   "type": "module",
   "description": "",
@@ -18,9 +18,9 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "agent-core": "*",
-    "mysql-rotator": "*",
-    "aws-utils": "*"
+    "@dopplerhq/agent-core": "*",
+    "@dopplerhq/mysql-rotator": "*",
+    "@dopplerhq/aws-utils": "*"
   },
   "secretAgentMeta": {
     "platform": "aws"

--- a/apps/aws-postgres-rotator/app.ts
+++ b/apps/aws-postgres-rotator/app.ts
@@ -1,6 +1,6 @@
-import { JWKSOption, processRequest } from "agent-core";
-import postgresHandler from "postgres-rotator";
-import { fetchS3KeySet } from "aws-utils";
+import { JWKSOption, processRequest } from "@dopplerhq/agent-core";
+import postgresHandler from "@dopplerhq/postgres-rotator";
+import { fetchS3KeySet } from "@dopplerhq/aws-utils";
 
 export async function handler(event: { body: string }) {
   let keySetOption: JWKSOption;

--- a/apps/aws-postgres-rotator/package.json
+++ b/apps/aws-postgres-rotator/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "aws-postgres-rotator",
+  "name": "@dopplerhq/aws-postgres-rotator",
   "version": "1.0.0",
   "type": "module",
   "description": "",
@@ -18,9 +18,9 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "agent-core": "*",
-    "postgres-rotator": "*",
-    "aws-utils": "*"
+    "@dopplerhq/agent-core": "*",
+    "@dopplerhq/postgres-rotator": "*",
+    "@dopplerhq/aws-utils": "*"
   },
   "secretAgentMeta": {
     "platform": "aws"

--- a/apps/http-postgres-rotator/index.ts
+++ b/apps/http-postgres-rotator/index.ts
@@ -1,6 +1,6 @@
-import { processRequest } from "agent-core";
+import { processRequest } from "@dopplerhq/agent-core";
 import express from "express";
-import postgresHandler from "postgres-rotator";
+import postgresHandler from "@dopplerhq/postgres-rotator";
 
 const app = express();
 app.use(express.text());

--- a/apps/http-postgres-rotator/package.json
+++ b/apps/http-postgres-rotator/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "http-postgres-rotator",
+  "name": "@dopplerhq/http-postgres-rotator",
   "version": "1.0.0",
   "type": "module",
   "description": "",
@@ -18,8 +18,8 @@
     "@types/express": "^4.17.13"
   },
   "dependencies": {
-    "agent-core": "*",
-    "postgres-rotator": "*",
+    "@dopplerhq/agent-core": "*",
+    "@dopplerhq/postgres-rotator": "*",
     "express": "^4.18.1"
   },
   "secretAgentMeta": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
       }
     },
     "agent-core": {
+      "name": "@dopplerhq/agent-core",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -41,12 +42,13 @@
       }
     },
     "apps/aws-mysql-rotator": {
+      "name": "@dopplerhq/aws-mysql-rotator",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "agent-core": "*",
-        "aws-utils": "*",
-        "mysql-rotator": "*"
+        "@dopplerhq/agent-core": "*",
+        "@dopplerhq/aws-utils": "*",
+        "@dopplerhq/mysql-rotator": "*"
       },
       "devDependencies": {
         "typescript": "^4.6.4"
@@ -56,12 +58,13 @@
       }
     },
     "apps/aws-postgres-rotator": {
+      "name": "@dopplerhq/aws-postgres-rotator",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "agent-core": "*",
-        "aws-utils": "*",
-        "postgres-rotator": "*"
+        "@dopplerhq/agent-core": "*",
+        "@dopplerhq/aws-utils": "*",
+        "@dopplerhq/postgres-rotator": "*"
       },
       "devDependencies": {
         "typescript": "^4.6.4"
@@ -71,12 +74,13 @@
       }
     },
     "apps/http-postgres-rotator": {
+      "name": "@dopplerhq/http-postgres-rotator",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "agent-core": "*",
-        "express": "^4.18.1",
-        "postgres-rotator": "*"
+        "@dopplerhq/agent-core": "*",
+        "@dopplerhq/postgres-rotator": "*",
+        "express": "^4.18.1"
       },
       "devDependencies": {
         "@types/express": "^4.17.13"
@@ -1622,6 +1626,34 @@
         "node": ">=12"
       }
     },
+    "node_modules/@dopplerhq/agent-core": {
+      "resolved": "agent-core",
+      "link": true
+    },
+    "node_modules/@dopplerhq/aws-mysql-rotator": {
+      "resolved": "apps/aws-mysql-rotator",
+      "link": true
+    },
+    "node_modules/@dopplerhq/aws-postgres-rotator": {
+      "resolved": "apps/aws-postgres-rotator",
+      "link": true
+    },
+    "node_modules/@dopplerhq/aws-utils": {
+      "resolved": "utils/aws",
+      "link": true
+    },
+    "node_modules/@dopplerhq/http-postgres-rotator": {
+      "resolved": "apps/http-postgres-rotator",
+      "link": true
+    },
+    "node_modules/@dopplerhq/mysql-rotator": {
+      "resolved": "rotators/mysql",
+      "link": true
+    },
+    "node_modules/@dopplerhq/postgres-rotator": {
+      "resolved": "rotators/postgres",
+      "link": true
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -2086,10 +2118,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/agent-core": {
-      "resolved": "agent-core",
-      "link": true
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2192,18 +2220,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/aws-mysql-rotator": {
-      "resolved": "apps/aws-mysql-rotator",
-      "link": true
-    },
-    "node_modules/aws-postgres-rotator": {
-      "resolved": "apps/aws-postgres-rotator",
-      "link": true
-    },
-    "node_modules/aws-utils": {
-      "resolved": "utils/aws",
-      "link": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -3478,10 +3494,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/http-postgres-rotator": {
-      "resolved": "apps/http-postgres-rotator",
-      "link": true
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -3964,10 +3976,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "node_modules/mysql-rotator": {
-      "resolved": "rotators/mysql",
-      "link": true
-    },
     "node_modules/mysql2": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.3.3.tgz",
@@ -4358,10 +4366,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/postgres-rotator": {
-      "resolved": "rotators/postgres",
-      "link": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -5141,11 +5145,11 @@
       }
     },
     "rotators/mysql": {
-      "name": "mysql-rotator",
+      "name": "@dopplerhq/mysql-rotator",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "agent-core": "*",
+        "@dopplerhq/agent-core": "*",
         "mysql2": "^2.3.3",
         "zod": "^3.17.3"
       },
@@ -5157,11 +5161,11 @@
       }
     },
     "rotators/postgres": {
-      "name": "postgres-rotator",
+      "name": "@dopplerhq/postgres-rotator",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "agent-core": "*",
+        "@dopplerhq/agent-core": "*",
         "pg": "^8.7.3",
         "pg-format": "^1.0.4",
         "zod": "^3.16.0"
@@ -5177,7 +5181,7 @@
       }
     },
     "utils/aws": {
-      "name": "aws-utils",
+      "name": "@dopplerhq/aws-utils",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6666,6 +6670,68 @@
         "@jridgewell/trace-mapping": "0.3.9"
       }
     },
+    "@dopplerhq/agent-core": {
+      "version": "file:agent-core",
+      "requires": {
+        "jose": "^4.11.0",
+        "zod": "^3.17.3"
+      }
+    },
+    "@dopplerhq/aws-mysql-rotator": {
+      "version": "file:apps/aws-mysql-rotator",
+      "requires": {
+        "@dopplerhq/agent-core": "*",
+        "@dopplerhq/aws-utils": "*",
+        "@dopplerhq/mysql-rotator": "*",
+        "typescript": "^4.6.4"
+      }
+    },
+    "@dopplerhq/aws-postgres-rotator": {
+      "version": "file:apps/aws-postgres-rotator",
+      "requires": {
+        "@dopplerhq/agent-core": "*",
+        "@dopplerhq/aws-utils": "*",
+        "@dopplerhq/postgres-rotator": "*",
+        "typescript": "^4.6.4"
+      }
+    },
+    "@dopplerhq/aws-utils": {
+      "version": "file:utils/aws",
+      "requires": {
+        "@aws-sdk/client-s3": "^3.128.0"
+      }
+    },
+    "@dopplerhq/http-postgres-rotator": {
+      "version": "file:apps/http-postgres-rotator",
+      "requires": {
+        "@dopplerhq/agent-core": "*",
+        "@dopplerhq/postgres-rotator": "*",
+        "@types/express": "^4.17.13",
+        "express": "^4.18.1"
+      }
+    },
+    "@dopplerhq/mysql-rotator": {
+      "version": "file:rotators/mysql",
+      "requires": {
+        "@dopplerhq/agent-core": "*",
+        "@types/mysql": "^2.15.21",
+        "mysql2": "^2.3.3",
+        "zod": "^3.17.3"
+      }
+    },
+    "@dopplerhq/postgres-rotator": {
+      "version": "file:rotators/postgres",
+      "requires": {
+        "@dopplerhq/agent-core": "*",
+        "@types/pg": "^8.6.5",
+        "@types/pg-format": "^1.0.2",
+        "pg": "^8.7.3",
+        "pg-format": "^1.0.4",
+        "prettier": "^2.6.2",
+        "typescript": "^4.6.4",
+        "zod": "^3.16.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -7009,13 +7075,6 @@
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
     },
-    "agent-core": {
-      "version": "file:agent-core",
-      "requires": {
-        "jose": "^4.11.0",
-        "zod": "^3.17.3"
-      }
-    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -7089,30 +7148,6 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.2",
         "es-shim-unscopables": "^1.0.0"
-      }
-    },
-    "aws-mysql-rotator": {
-      "version": "file:apps/aws-mysql-rotator",
-      "requires": {
-        "agent-core": "*",
-        "aws-utils": "*",
-        "mysql-rotator": "*",
-        "typescript": "^4.6.4"
-      }
-    },
-    "aws-postgres-rotator": {
-      "version": "file:apps/aws-postgres-rotator",
-      "requires": {
-        "agent-core": "*",
-        "aws-utils": "*",
-        "postgres-rotator": "*",
-        "typescript": "^4.6.4"
-      }
-    },
-    "aws-utils": {
-      "version": "file:utils/aws",
-      "requires": {
-        "@aws-sdk/client-s3": "^3.128.0"
       }
     },
     "balanced-match": {
@@ -8102,15 +8137,6 @@
         "toidentifier": "1.0.1"
       }
     },
-    "http-postgres-rotator": {
-      "version": "file:apps/http-postgres-rotator",
-      "requires": {
-        "@types/express": "^4.17.13",
-        "agent-core": "*",
-        "express": "^4.18.1",
-        "postgres-rotator": "*"
-      }
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -8458,15 +8484,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "mysql-rotator": {
-      "version": "file:rotators/mysql",
-      "requires": {
-        "@types/mysql": "^2.15.21",
-        "agent-core": "*",
-        "mysql2": "^2.3.3",
-        "zod": "^3.17.3"
-      }
-    },
     "mysql2": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.3.3.tgz",
@@ -8757,19 +8774,6 @@
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
       "requires": {
         "xtend": "^4.0.0"
-      }
-    },
-    "postgres-rotator": {
-      "version": "file:rotators/postgres",
-      "requires": {
-        "@types/pg": "^8.6.5",
-        "@types/pg-format": "^1.0.2",
-        "agent-core": "*",
-        "pg": "^8.7.3",
-        "pg-format": "^1.0.4",
-        "prettier": "^2.6.2",
-        "typescript": "^4.6.4",
-        "zod": "^3.16.0"
       }
     },
     "prelude-ls": {

--- a/rotators/mysql/lib/index.ts
+++ b/rotators/mysql/lib/index.ts
@@ -1,6 +1,6 @@
 import mysql, { QueryError } from "mysql2/promise";
 import { z } from "zod";
-import { Request, Response, AgentError } from "agent-core";
+import { Request, Response, AgentError } from "@dopplerhq/agent-core";
 
 const SSL_SCHEMA = z
   .object({

--- a/rotators/mysql/package.json
+++ b/rotators/mysql/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mysql-rotator",
+  "name": "@dopplerhq/mysql-rotator",
   "version": "1.0.0",
   "type": "module",
   "description": "",
@@ -15,7 +15,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "agent-core": "*",
+    "@dopplerhq/agent-core": "*",
     "mysql2": "^2.3.3",
     "zod": "^3.17.3"
   },

--- a/rotators/postgres/lib/index.ts
+++ b/rotators/postgres/lib/index.ts
@@ -1,7 +1,7 @@
 import pg from "pg";
 import pgFormat from "pg-format";
 import { z } from "zod";
-import { Request, Response, AgentError } from "agent-core";
+import { Request, Response, AgentError } from "@dopplerhq/agent-core";
 
 const SSL_SCHEMA = z
   .object({

--- a/rotators/postgres/package.json
+++ b/rotators/postgres/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "postgres-rotator",
+  "name": "@dopplerhq/postgres-rotator",
   "version": "1.0.0",
   "type": "module",
   "description": "",
@@ -24,6 +24,6 @@
     "pg": "^8.7.3",
     "pg-format": "^1.0.4",
     "zod": "^3.16.0",
-    "agent-core": "*"
+    "@dopplerhq/agent-core": "*"
   }
 }

--- a/utils/aws/package.json
+++ b/utils/aws/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "aws-utils",
+  "name": "@dopplerhq/aws-utils",
   "version": "1.0.0",
   "type": "module",
   "description": "",


### PR DESCRIPTION
This changes moves all internal npm packages to the `@dopplerhq` scope. Although internal packages were only used within the npm workspace (and locked via `package-lock.json`), it's a good practice to keep these packages under a Doppler-controlled scope to eliminate any possibility of a dependency confusion attack.

Closes ENG-5659