### PR TITLE
Update zod version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
     },
     "apps/aws-mysql-rotator": {
       "name": "@dopplerhq/aws-mysql-rotator",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@dopplerhq/agent-core": "*",
@@ -59,7 +59,7 @@
     },
     "apps/aws-postgres-rotator": {
       "name": "@dopplerhq/aws-postgres-rotator",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@dopplerhq/agent-core": "*",
@@ -5281,9 +5281,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.3.tgz",
-      "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -9576,9 +9576,9 @@
       "dev": true
     },
     "zod": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.3.tgz",
-      "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg=="
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="
     }
   }
 }


### PR DESCRIPTION
Addresses npm audit issue.

```
# npm audit report

zod  <=3.22.2
Zod denial of service vulnerability - https://github.com/advisories/GHSA-m95q-7qp3-xv42
fix available via `npm audit fix`
node_modules/zod

1 low severity vulnerability

To address all issues, run:
  npm audit fix
```