### PR TITLE
Update workflow dependencies and pin versions

### DIFF
--- a/.github/workflows/scanners.yaml
+++ b/.github/workflows/scanners.yaml
@@ -1,20 +1,18 @@
 name: Scanners
 
 on:
-  push:
-  schedule:
-    - cron: "0 0 * * *"
+  pull_request:
 
 jobs:
   npm_build:
     runs-on: ubuntu-latest
     name: build + lint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: npm Build
         run: npm install
       - run: set -eo pipefail; npm run build && npm run lint 2>&1| tee ./linter-report.txt
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: NPM Linter Report
@@ -24,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     name: prettier
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: npm Build
         run: npm install
       - run: set -eo pipefail; npm run prettier 2>&1| tee ./prettier-report.txt
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: NPM Prettier Report
@@ -38,8 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     name: npm audit
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
Also removes the schedule trigger, since we rely now on GH for continuous scanning.